### PR TITLE
Test content-type and charset are stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current (in progress)
 
 - Add pyOpenSSL requirement for python3.7 compatibility [#197](https://github.com/etalab/croquemort/pull/197)
+- Clarify that the `Content-Type` HTTP header is cleaned [#202](https://github.com/etalab/croquemort/pull/202)
 
 ## 2.1.0 (2019-05-07)
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Date: Wed, 03 Jun 2015 14:22:57 GMT
   "updated": "2015-06-03T16:21:52.569974",
   "last-modified": "",
   "content-encoding": "gzip",
-  "content-type": "text/html; charset=utf-8"
+  "content-type": "text/html",
+  "charset": "utf-8"
 }
 ```
 
@@ -139,7 +140,8 @@ Date: Wed, 03 Jun 2015 14:23:35 GMT
   "updated": "2015-06-03T16:21:52.569974",
   "last-modified": "",
   "content-encoding": "gzip",
-  "content-type": "text/html; charset=utf-8"
+  "content-type": "text/html",
+  "charset": "utf-8"
 }
 ```
 
@@ -200,7 +202,8 @@ Date: Wed, 03 Jun 2015 14:26:04 GMT
     "content-location": "",
     "content-length": "",
     "expires": "",
-    "content-type": "text/html; charset=utf-8",
+    "content-type": "text/html",
+    "charset": "utf-8",
     "final-status-code": "200",
     "updated": "2015-06-03T16:24:02.398105",
     "etag": "",
@@ -233,7 +236,8 @@ Date: Wed, 03 Jun 2015 14:23:35 GMT
   "updated": "2015-06-03T16:21:52.569974",
   "last-modified": "",
   "content-encoding": "gzip",
-  "content-type": "text/html; charset=utf-8"
+  "content-type": "text/html",
+  "charset": "utf-8"
 }
 ```
 
@@ -260,7 +264,8 @@ Both when fetching one and many urls, croquemort has basic support of HTTP redir
   "updated": "2015-06-03T16:21:52.569974",
   "last-modified": "",
   "content-encoding": "gzip",
-  "content-type": "text/html; charset=utf-8"  
+  "content-type": "text/html",
+  "charset": "utf-8"
 }
 ```
 

--- a/tests/services/test_crawler.py
+++ b/tests/services/test_crawler.py
@@ -85,7 +85,7 @@ def test_store_no_redirect(
     assert stored['final-url'] == 'http://no-redirect.com'
     assert stored['final-status-code'] == '200'
     assert stored['checked-url'] == 'http://no-redirect.com'
-    assert stored['content-type'] == 'text/html; charset=utf-8'
+    assert stored['content-type'] == 'text/html'
     assert stored['charset'] == 'utf-8'
     assert stored.get('url') is None
     assert stored.get('status') is None

--- a/tests/services/test_crawler.py
+++ b/tests/services/test_crawler.py
@@ -85,7 +85,7 @@ def test_store_no_redirect(
     assert stored['final-url'] == 'http://no-redirect.com'
     assert stored['final-status-code'] == '200'
     assert stored['checked-url'] == 'http://no-redirect.com'
-    assert stored['content-type'] == 'text/html'
+    assert stored['content-type'] == 'text/html; charset=utf-8'
     assert stored['charset'] == 'utf-8'
     assert stored.get('url') is None
     assert stored.get('status') is None

--- a/tests/services/test_crawler.py
+++ b/tests/services/test_crawler.py
@@ -71,7 +71,7 @@ def test_store_redirect_metadata(
 
 def test_store_no_redirect(
         container_factory, rabbit_config, web_container_config):
-    headers = {'content-type': 'text/html; charset=utf-8'}
+    headers = {'content-type': 'text/html; charset=utf-8', 'content-length': '227090'}
     res = DummyResponse('http://no-redirect.com', 200, headers, [])
     crawler_container = container_factory(CrawlerService, web_container_config)
     crawler_container.start()
@@ -87,6 +87,7 @@ def test_store_no_redirect(
     assert stored['checked-url'] == 'http://no-redirect.com'
     assert stored['content-type'] == 'text/html'
     assert stored['charset'] == 'utf-8'
+    assert stored['content-length'] == '227090'
     assert stored.get('url') is None
     assert stored.get('status') is None
 

--- a/tests/services/test_crawler.py
+++ b/tests/services/test_crawler.py
@@ -71,7 +71,8 @@ def test_store_redirect_metadata(
 
 def test_store_no_redirect(
         container_factory, rabbit_config, web_container_config):
-    res = DummyResponse('http://no-redirect.com', 200, None, [])
+    headers = {'content-type': 'text/html; charset=utf-8'}
+    res = DummyResponse('http://no-redirect.com', 200, headers, [])
     crawler_container = container_factory(CrawlerService, web_container_config)
     crawler_container.start()
     storage = get_extension(crawler_container, RedisStorage)
@@ -84,6 +85,8 @@ def test_store_no_redirect(
     assert stored['final-url'] == 'http://no-redirect.com'
     assert stored['final-status-code'] == '200'
     assert stored['checked-url'] == 'http://no-redirect.com'
+    assert stored['content-type'] == 'text/html'
+    assert stored['charset'] == 'utf-8'
     assert stored.get('url') is None
     assert stored.get('status') is None
 


### PR DESCRIPTION
There is a logic to clean the returned `Content-Type` header to store the content type and the charset in different fields.

https://github.com/etalab/croquemort/blob/eb972ebee6a17c16ac838edffdaa1d3c3ea23b6e/croquemort/storages.py#L107-L121

I added a test to verify this behaviour and corrected the documentation.

## Questions

I didn't commit a CHANGELOG as I don't know if you want to release a minor for tests + documentation fixes.

## Remarks
I didn't run tests locally as I didn't want to setup AMQP / Redis. I made sure that the test was working by showing a failure and reverting the commit afterwards. This can be seen in the commit log and on CircleCI.